### PR TITLE
Add python3 shebang line

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from pathlib import Path
 from PyQt6 import uic, QtWidgets
 from PyQt6.QtWidgets import QFileDialog


### PR DESCRIPTION
This add the python3 shebang at the top of `main.py`, allowing users to run it directly instead of having to explicitly invoke the python interpreter.

Without this line, running `main.py` directly from a shell would try to run it as a shell script instead, which obviously won't work :shrug: 